### PR TITLE
refactor: misc. tera improvements

### DIFF
--- a/vtop.tera
+++ b/vtop.tera
@@ -6,37 +6,40 @@ whiskers:
     - accent
   filename: "themes/{{ flavor.identifier }}/catppuccin-{{ flavor.identifier }}-{{ accent }}.json"
 ---
+
+{%- set accent = flavor.colors[accent] -%}
+
 {
-	"name": "Catppuccin {{ flavor.name }} with {{accent}} accent",
-	"author": "AlwaysNur",
+	"name": "Catppuccin {{ flavor.name }} ({{ accent.name }})"",
+	"author": "Catppuccin",
 	"title": {
-		"fg": "#{{flavor.colors.text.hex}}"	
+		"fg": "#{{ text.hex }}"	
 	},
 	"chart": {
-		"fg": "#{{flavor.colors[accent].hex}}",
+		"fg": "#{{ accent.hex }}",
 		"border": {
 			"type": "line",
-			"fg": "#{{flavor.colors.overlay0.hex}}"
+			"fg": "#{{ overlay0.hex }}"
 		}
 	},
 	"table": {
-		"fg": "#{{flavor.colors.text.hex}}",
+		"fg": "#{{ text.hex }}",
 		"items": {
 			"selected": {
-				"bg": "#{{flavor.colors[accent].hex}}",
-				"fg": "#{{flavor.colors.surface0.hex}}"
+				"bg": "#{{ accent.hex }}",
+				"fg": "#{{ surface0.hex }}"
 			},
 			"item": {
-				"fg": "#{{flavor.colors.subtext1.hex}}"
+				"fg": "#{{ subtext1.hex }}"
 			}
 		},
 		"border": {
 			"type": "line",
-			"fg": "#{{flavor.colors.overlay0.hex}}"	
+			"fg": "#{{ overlay0.hex }}"	
 		}
 	},
 	"footer": {
-		"fg": "#{{flavor.colors.text.hex}}"
+		"fg": "#{{ text.hex }}"
 	}
 }
 


### PR DESCRIPTION
1. We can set the `accent` variable to be a color variable like the rest of the colors, also lets us use the `accent.name` property on line 13.
2. Author field should be Catppuccin (line 14).
3. When using the `whiskers.matrix` with `flavor`, the color variables are available at the top level/scope - you only need `red.hex`, not `flavor.colors.red.hex`.
4. Minor formatting to add spaces before/after {{/}}.